### PR TITLE
Fix averaging grades when list is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ git clone https://github.com/RustySnek/librus-apix
 cd librus-apix
 python -m venv venv
 source ./venv/bin/activate
-pip install requirements.txt
+pip install -r requirements.txt
 # Installing library with editable flag
 pip install -e .
 ```

--- a/librus_apix/grades.py
+++ b/librus_apix/grades.py
@@ -272,7 +272,7 @@ def _extract_grades_numeric(
                     sem_grades[semester_number][subject].append(g)
             avg_gr = (
                 average_grades[semester_number]
-                if len(average_grades) >= semester_number
+                if len(average_grades) > semester_number
                 else 0.0
             )  # might happen that the list is empty
             gpa = Gpa(semester_number + 1, avg_gr, subject)


### PR DESCRIPTION
Fix no empty list case when averaging grades. As bonus, there was missing `-r` parameter when installing dependencies from `requirements.txt` file.